### PR TITLE
fix: deployment should be created from 'hello-world/Hello'

### DIFF
--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -379,7 +379,7 @@ ground control and data collection of the deployment.
 
 To create a deployment, run the following commands:
 ```bash
-# In: hello-world
+# In: hello-world/Hello
 fprime-util new --deployment
 ```
 This command will ask for some input. Respond with the following answers:

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -377,9 +377,10 @@ F´ deployments represent one flight software executable. All the components we 
 The deployment created here will contain the standard command and data handling stack. This stack enables
 ground control and data collection of the deployment.
 
-To create a deployment, run the following commands:
+To create a deployment, `cd` into the `Hello` directory (this is the top-level namespace where project code should reside) and run the following:
 ```bash
-# In: hello-world/Hello
+# In: hello-world
+cd Hello/
 fprime-util new --deployment
 ```
 This command will ask for some input. Respond with the following answers:


### PR DESCRIPTION
This is with reference to https://github.com/nasa/fprime/pull/4353

Running:
```fprime
fprime-util new --deployment
```

in the project folder creates a deployment in the project folder and not the namespace folder:
```
(fprime-venv) saransh@Saranshs-MacBook-Air-3 hello-world % fprime-util new --deployment
[INFO] Cookiecutter: using builtin template for new deployment
  [1/3] Deployment name (MyDeployment): HelloWorldDeployment
  [2/3] Deployment namespace (HelloWorldDeployment): 
```

but running inside the namespace folder does the expected thing (with fprime `v4.1.0`)
```
(fprime-venv) saransh@Saranshs-MacBook-Air-3 hello-world % cd Hello                    
(fprime-venv) saransh@Saranshs-MacBook-Air-3 Hello % fprime-util new --deployment
[INFO] Cookiecutter: using builtin template for new deployment
  [1/3] Deployment name (MyDeployment): HelloWorldDeployment
  [2/3] Deployment namespace (Hello): 
```

cc: @thomas-bc 

I can also create PRs for the other tutorials of this looks good!