### PR TITLE
Fix unnecessary constructor reference in Hello World tutorial

### DIFF
--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -505,7 +505,7 @@ void HiComponent ::SAY_HI_cmdHandler(FwOpcodeType opCode, U32 cmdSeq, const Fw::
 **`HiComponent.hpp`: Declare Counting Variable**
 
 Add the m_greetingCount member variable to the class defined in
-`HiComponent.hpp` and the constructor defined in `HiComponent.cpp`.
+`HiComponent.hpp` and initialize it to zero.
 This is done by adding the following two lines inside
 the `class` definition in `HiComponent.hpp`:
 


### PR DESCRIPTION
While following the tutorial in GitHub Codespaces, I noticed that section 2e refers to modifying the constructor in HiComponent.cpp, but the example only uses inline member initialization in HiComponent.hpp.

The tutorial mentions adding m_greetingCount to both
HiComponent.hpp and the constructor in HiComponent.cpp.

However, the example uses inline member initialization:

    U32 m_greetingCount = 0;

and no constructor modification is required.

This PR updates the tutorial text to match the code example.